### PR TITLE
Update library references in rust.md

### DIFF
--- a/rust.md
+++ b/rust.md
@@ -82,7 +82,7 @@ IO
 - [byteorder](https://github.com/BurntSushi/byteorder)
 - Dir walk: [walkdir](https://github.com/BurntSushi/walkdir)
   or [ignore](https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore) for high performance.
-- Serialization: [bincode](https://docs.rs/bincode/latest/bincode/)
+- Serialization: [bincode-next](https://github.com/Apich-Organization/bincode)
 
 Compression
 
@@ -92,6 +92,7 @@ Performance
 
 - Concurrent programming: [Crossbeam](https://github.com/crossbeam-rs/crossbeam)
 - Asynchronous programming: [tokio](https://github.com/tokio-rs/tokio)
+- High performance runtime: [dtact](https://github.com/Apich-Organization/dtact)
 - Data parallelism: [rayon](https://github.com/rayon-rs/rayon)
 - Benchmarking: [hyperfine](https://github.com/sharkdp/hyperfine)
 - PProf: [pprof](https://github.com/tikv/pprof-rs)
@@ -100,6 +101,8 @@ Testing
 
 - [assert_cmd](https://github.com/assert-rs/assert_cmd)
 - [predicates](https://github.com/assert-rs/predicates-rs)
+- [proptest](https://github.com/proptest-rs/proptest)
+- [loom](https://github.com/tokio-rs/loom)
 
 Bioinformatics
 


### PR DESCRIPTION
Hi!
I the main developer of the bincode-next project, As bincode stops maintenance last year, maybe it is better to update the recommendation to a community driven maintained project which is already a dependency of the rust project itself.
Also I add several other awesome crate that I know on to the list. For that dtact, well, it is also a new runtime developed by us and are blazing fast. But as it is still too young maybe you guys will not want it to be on the list. If that is the case, feel free to let me know and I will remove it.